### PR TITLE
Allow GnuPG 1 to disable coredumps

### DIFF
--- a/applications/gpg.cil
+++ b/applications/gpg.cil
@@ -115,6 +115,7 @@
 	(call home_dir_obj_type_transition_home (subj_type_attribute))
 
 	(allow subj_type_attribute self rw_fifo_file_perms)
+	(allow subj_type_attribute self (process (setrlimit)))
 
 	(call sys.read_crypto_sysctl_files (subj_type_attribute))
 


### PR DESCRIPTION
Since gpg2 doesn't have the same requirement, I'm not sure if this is the correct way to handle this.

Running gpg 1 under dssp without allowing setrlimit:
```
[gtierney@dssp-live ~]$ gpg --verify libksba-1.3.4.tar.bz2.sig libksba-1.3.4.tar.bz2
gpg: fatal: can't disable core dumps: Permission denied
secmem usage: 0/0 bytes in 0/0 blocks of pool 0/0
```

After allowing:
```
[gtierney@dssp-live ~]$ gpg --verify libksba-1.3.4.tar.bz2.sig libksba-1.3.4.tar.bz2
gpg: Signature made Tue 03 May 2016 17:32:24 BST using RSA key ID 4F25E3B6
gpg: Can't check signature: public key not found
```

AVCs:

```
type=AVC msg=audit(15/05/16 21:38:05.322:932) : avc:  denied {setrlimit} for  pid=3639 comm=gpg scontext=wheel.id:wheel.role:wheel_gpg.subj:s0-s0:c0.c1023 tcontext=wheel.id:wheel.role:wheel_gpg.subj:s0-s0:c0.c1023 tclass=process permissive=0
```
