### PR TITLE
Misc timedate/locale fixes

### DIFF
--- a/sd/sd_timedated.cil
+++ b/sd/sd_timedated.cil
@@ -49,6 +49,7 @@
 	(call term.use_console (subj))
 
 	(call hwclock.read_config_files (subj))
+	(allow subj self (capability (sys_time)))
 
 	(call file.manage_config_lnk_files (subj))
 

--- a/sd/sd_timedated.cil
+++ b/sd/sd_timedated.cil
@@ -50,6 +50,8 @@
 
 	(call hwclock.read_config_files (subj))
 
+	(call file.manage_config_lnk_files (subj))
+
 	(call locale.client_subj_type (subj))
 
 	(call sd.notify_subj_type (subj))

--- a/sd/sduser.cil
+++ b/sd/sduser.cil
@@ -858,6 +858,8 @@
 	(call manage_tmpfs_user (subj_type_attribute))
 	(call manage_unit_runtime (subj_type_attribute))
 
+	(call hwclock.read_config_files (subj_type_attribute))
+
 	(call tmpfs_obj_type_transition_private_tmpfs (subj_type_attribute))
 	(call tmpfs_obj_type_transition_tmpfs (subj_type_attribute))
 	(call tmpfs_obj_type_transition_tmpfs_files (subj_type_attribute))


### PR DESCRIPTION
Couple of issues that I ran into here:

* systemd --user tries to read /etc/adjtime on `systemd --user status` and defaults to UTC on failure.
* using timedatectl to change timezone / time fails because timedated (not timedatex, which currently works) can't manage symlinks labeled as config.config_file.
* timedated's syscalls to clock_settime() will fail with EPERM

AVCs for timedated reading/writing `config.config_files` and calling clock_settime:
````
----
time->Wed Jun  1 14:12:01 2016
type=AVC msg=audit(1464790321.401:795): avc:  denied  { add_name } for  pid=26602 comm="systemd-timedat" name=".#localtimefcd3e01e97f6dd68
" scontext=sys.id:sys.role:sd_timedated.subj:s0 tcontext=sys.id:sys.role:config.config_file:s0 tclass=dir permissive=1
----
time->Wed Jun  1 14:12:01 2016
type=AVC msg=audit(1464790321.402:796): avc:  denied  { create } for  pid=26602 comm="systemd-timedat" name=".#localtimefcd3e01e97f6dd68" 
scontext=sys.id:sys.role:sd_timedated.subj:s0 tcontext=sys.id:sys.role:config.config_file:s0 tclass=lnk_file permissive=1
----
time->Wed Jun  1 14:12:01 2016
type=AVC msg=audit(1464790321.402:797): avc:  denied  { rename } for  pid=26602 comm="systemd-timedat" name=".#localtimefcd3e01e97f6dd68" 
dev="vda3" ino=59720 scontext=sys.id:sys.role:sd_timedated.subj:s0 tcontext=sys.id:sys.role:config.config_file:s0 tclass=lnk_file permissi
ve=1
----
time->Wed Jun  1 14:12:01 2016
type=AVC msg=audit(1464790321.402:798): avc:  denied  { unlink } for  pid=26602 comm="systemd-timedat" name="localtime" dev="vda3" ino=337
71 scontext=sys.id:sys.role:sd_timedated.subj:s0 tcontext=sys.id:sys.role:config.config_file:s0 tclass=lnk_file permissive=1
----
time->Wed Jun  1 14:12:01 2016
type=AVC msg=audit(1464790321.402:799): avc:  denied  { sys_time } for  pid=26602 comm="systemd-timedat" capability=25  scontext=sys.id:sy
s.role:sd_timedated.subj:s0 tcontext=sys.id:sys.role:sd_timedated.subj:s0 tclass=capability permissive=1
----
``` 

systemd --user status AVCs
```
----
time->Wed Jun  1 14:37:03 2016
type=AVC msg=audit(1464791823.441:818): avc:  denied  { read } for  pid=701 comm="systemd" name="adjtime" dev="vda3" ino=19437 scontext=wheel.id:wheel.role:wheel_sduser.subj:s0-s0:c0.c1023 tcontext=sys.id:sys.role:hwclock.config_file:s0 tclass=file permissive=1
----
```