### PR TITLE
sd_shutdown: remove conflicting file context spec

### DIFF
--- a/sd/sd_shutdown.cil
+++ b/sd/sd_shutdown.cil
@@ -6,8 +6,6 @@
 (in sd_shutdown
 	(filecon "/usr/lib/systemd/systemd-shutdown" file cmd_file_context))
 
-(filecon "/usr/lib/systemd/system-shutdown(/.*)?" file cmd)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ; Macros


### PR DESCRIPTION
Removes an older(?) file context spec for sd_shutdown which seems to be a duplicate of: https://github.com/DefenSec/dssp-contrib/blob/master/sd/sd.cil#L59

semodule fails on this with the following output:

```
/etc/selinux/dssp/contexts/files/file_contexts: Multiple different specifications for /usr/lib/systemd/system-shutdown(/.*)?  (sys.id:sys.role:cmd.cmd_file:s0 and sys.id:sys.role:sd_helper.cmd_file:s0).
/etc/selinux/dssp/contexts/files/file_contexts: Invalid argument
libsemanage.semanage_install_final_tmp: setfiles returned error code 1. (No such file or directory).
/etc/selinux/dssp/contexts/files/file_contexts: Multiple different specifications for /usr/lib/systemd/system-shutdown(/.*)?  (sys.id:sys.role:cmd.cmd_file:s0 and sys.id:sys.role:sd_helper.cmd_file:s0).
/etc/selinux/dssp/contexts/files/file_contexts: Invalid argument
libsemanage.semanage_install_final_tmp: setfiles returned error code 1. (No such file or directory).
/sbin/semodule:  Failed!
```